### PR TITLE
Feat: Swagger 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
 	//web socket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/meetup/teame/backend/HealthCheckController.java
+++ b/src/main/java/com/meetup/teame/backend/HealthCheckController.java
@@ -1,10 +1,12 @@
 package com.meetup.teame.backend;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Hidden
 @RequestMapping("/healths")
 public class HealthCheckController {
     @GetMapping

--- a/src/main/java/com/meetup/teame/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/meetup/teame/backend/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.meetup.teame.backend.domain.user.controller;
 
 import com.meetup.teame.backend.domain.user.dto.response.ReadMainRes;
 import com.meetup.teame.backend.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,9 +13,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
+@Tag(name = "user", description = "유저 관련 api")
 public class UserController {
     private final UserService userService;
 
+    @Operation(summary = "메인 페이지 조회", description = """
+            현재 로그인한 유저의 메인 페이지를 조회합니다.
+            
+            아직 로그인이 없어서 임시로 고정된 더미 유저의 데이터를 전달하는 식으로 구현되어 있습니다.
+            
+            추후 로그인 적용 시에는 jwt토큰도 같이 전달해서 요청해주셔야 합니다.
+            """)
     @GetMapping("/main")
     public ResponseEntity<ReadMainRes> readMainPage() {
         return ResponseEntity

--- a/src/main/java/com/meetup/teame/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/meetup/teame/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,47 @@
+package com.meetup.teame.backend.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@OpenAPIDefinition(
+        servers = @Server(url = "/"),
+        info = @Info(
+                title = "🚀 또바 API 명세서",
+                description = """
+                        spring docs 를 이용한 API 명세서 입니다.😊
+                        """,
+                version = "1.0",
+                contact = @Contact(
+                        name = "springdoc 공식문서",
+                        url = "https://springdoc.org/"
+                )
+        )
+)
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("JWT", bearerAuth()))
+                .addSecurityItem(new SecurityRequirement().addList("JWT"));
+    }
+
+    private SecurityScheme bearerAuth() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+    }
+}


### PR DESCRIPTION
## 변경 사항
- swagger 적용

## 설명
"서버URL/swagger-ui/index.html#/" 또는 "localhost/swagger-ui/index.html#/" 로 접속시 swagger 문서를 확인할 수 있습니다!

Controller의 함수 작성시 자동으로 swagger에 등록되고, 아래와 같이 설명을 입력해 줄 수도 있습니다!
```java
    @Operation(summary = "메인 페이지 조회", description = """
            현재 로그인한 유저의 메인 페이지를 조회합니다.
            
            아직 로그인이 없어서 임시로 고정된 더미 유저의 데이터를 전달하는 식으로 구현되어 있습니다.
            
            추후 로그인 적용 시에는 jwt토큰도 같이 전달해서 요청해주셔야 합니다.
            """)
    @GetMapping("/main")
    public ResponseEntity<ReadMainRes> readMainPage() {
        return ResponseEntity
                .ok(userService.readMainPage());
    }
```